### PR TITLE
Fixed typo opendta.si->opendata.si in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ Vsak klic v primeru napake vrne odgovor::
 Podatki
 =======
 
-Podatki so trenutno na voljo na www.opendta.si. Hostname se lahko v
+Podatki so trenutno na voljo na www.opendata.si. Hostname se lahko v
 prihodnje spremeni.
 
 Dogodki na cestah


### PR DESCRIPTION
Clicked the wrong link a couple of times, and it started to bother me :)
